### PR TITLE
Integrate window size classes and adaptive library support

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
             android:icon="@mipmap/ic_launcher"
             android:theme="@style/Theme.Solitaire">
         <activity android:name=".MainActivity"
-                  android:screenOrientation="sensorPortrait"
+                  android:resizeableActivity="true"
                   android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -82,6 +82,8 @@ kotlin {
                 api(compose.ui)
                 api(compose.foundation)
                 api(compose.materialIconsExtended)
+                api(libs.material3.window.size)
+                implementation(libs.adaptive)
                 api(compose.material3)
                 api(libs.kotlinx.datetime)
                 api(libs.navigation.compose)

--- a/common/src/commonMain/kotlin/com/programmersbox/common/App.kt
+++ b/common/src/commonMain/kotlin/com/programmersbox/common/App.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import kotlinx.serialization.Serializable
 
 @Composable
 internal fun App(
@@ -42,6 +43,7 @@ internal fun App(
     }
 }
 
+@Serializable
 sealed class Screen(val route: String) {
     data object Solitaire : Screen("solitaire")
 }

--- a/common/src/commonMain/kotlin/com/programmersbox/common/SolitaireScreen.kt
+++ b/common/src/commonMain/kotlin/com/programmersbox/common/SolitaireScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.AutoMode
 import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.window.core.layout.WindowWidthSizeClass
 import com.materialkolor.ktx.fixIfDisliked
 import com.materialkolor.ktx.harmonize
 import com.materialkolor.ktx.harmonizeWithPrimary
@@ -172,6 +174,8 @@ internal fun SolitaireScreen(
             .launchIn(this)
     }
 
+    val window = currentWindowAdaptiveInfo().windowSizeClass
+
     val snackbarHostState = remember { SnackbarHostState() }
 
     ModalNavigationDrawer(
@@ -296,20 +300,45 @@ internal fun SolitaireScreen(
                         .padding(horizontal = 4.dp)
                         .padding(padding)
                 ) {
-                    Foundations(
-                        info = info,
-                        winModifier = winModifier,
-                        cardBack = cardBack,
-                        database = database
-                    )
-                    //---------draws---------
-                    Draws(
-                        winModifier = winModifier,
-                        info = info,
-                        drawAmount = drawAmount,
-                        cardBack = cardBack,
-                        database = database,
-                    )
+                    when (window.windowWidthSizeClass) {
+                        WindowWidthSizeClass.MEDIUM, WindowWidthSizeClass.EXPANDED -> {
+                            Row {
+                                Foundations(
+                                    info = info,
+                                    winModifier = winModifier,
+                                    cardBack = cardBack,
+                                    database = database,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                //---------draws---------
+                                Draws(
+                                    winModifier = winModifier,
+                                    info = info,
+                                    drawAmount = drawAmount,
+                                    cardBack = cardBack,
+                                    database = database,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                        }
+
+                        else -> {
+                            Foundations(
+                                info = info,
+                                winModifier = winModifier,
+                                cardBack = cardBack,
+                                database = database
+                            )
+                            //---------draws---------
+                            Draws(
+                                winModifier = winModifier,
+                                info = info,
+                                drawAmount = drawAmount,
+                                cardBack = cardBack,
+                                database = database,
+                            )
+                        }
+                    }
                     //---------field---------
                     Field(
                         winModifier = winModifier,
@@ -348,13 +377,14 @@ private fun Foundations(
     database: SolitaireDatabase,
     cardBack: CardBack,
     winModifier: Modifier,
+    modifier: Modifier = Modifier,
 ) {
     val useNewDesign by rememberUseNewDesign()
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
+            //.fillMaxWidth()
             .animateContentSize()
     ) {
         info.foundations.forEach { foundation ->
@@ -435,12 +465,13 @@ private fun Draws(
     cardBack: CardBack,
     drawAmount: Int,
     database: SolitaireDatabase,
+    modifier: Modifier = Modifier,
 ) {
     val useNewDesign by rememberUseNewDesign()
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.End),
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy((-50).dp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
+adaptiveVersion = "1.0.0-rc01"
 filekitComposeVersion = "0.8.7"
 hypnoticcanvas = "0.1.2"
 kotlinx-serialization-json-version = "1.7.3"
+material3WindowSizeClassVersion = "1.7.0"
 navigation-compose-version = "2.7.0-alpha07"
 lifecycle-viewmodel-compose-version = "2.8.2"
 kotlin-version = "2.0.21"
@@ -26,6 +28,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "androidx-room" }
 
 [libraries]
+adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptive", version.ref = "adaptiveVersion" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.0" }
 androidx-core = { module = "androidx.core:core-ktx", version = "1.13.1" }
 androidx-activity-compose = "androidx.activity:activity-compose:1.9.3"
@@ -34,6 +37,7 @@ hypnoticcanvas = { module = "com.mikepenz.hypnoticcanvas:hypnoticcanvas", versio
 hypnoticcanvas-shaders = { module = "com.mikepenz.hypnoticcanvas:hypnoticcanvas-shaders", version.ref = "hypnoticcanvas" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json-version" }
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle-viewmodel-compose-version" }
+material3-window-size = { module = "org.jetbrains.compose.material3:material3-window-size-class", version.ref = "material3WindowSizeClassVersion" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation-compose-version" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore-version" }


### PR DESCRIPTION
---

**Description:**

- Add `WindowSizeClass` and `currentWindowAdaptiveInfo` for responsive UI layouts.
- Update build.gradle to include `material3-window-size` and `adaptive` dependencies.
- Modify `AndroidManifest.xml` to enable `resizeableActivity`.
- Apply @Serializable to `Screen` class.
- Refactor `SolitaireScreen` to adapt layouts based on window size.